### PR TITLE
fix recusrive parsing in the list_jobs endpoint

### DIFF
--- a/src/jenkins_mcp_server/docker/run.server.tests
+++ b/src/jenkins_mcp_server/docker/run.server.tests
@@ -61,6 +61,9 @@ docker run -t --rm \
     -e JENKINS_USER=${JENKINS_USER} \
     -e JENKINS_API_TOKEN=${JENKINS_API_TOKEN} \
     -e MCP_API_KEY=${MCP_API_KEY} \
+    -e LOG_LEVEL=${LOG_LEVEL:-INFO} \
+    -e DEBUG_MODE=${DEBUG_MODE:-False} \
+    -e WRITE_LOG_TO_FILE_FOR_TESTS=true \
     --network host \
     --entrypoint pytest \
     "$IMAGE_NAME" \

--- a/src/jenkins_mcp_server/tests/functional/test_server.py
+++ b/src/jenkins_mcp_server/tests/functional/test_server.py
@@ -149,10 +149,12 @@ def test_list_jobs_recursive(server_process):
         for job in actual_jobs_recursive: # Could use either list as counts are same
             if "/" in job.get("name", ""):
                 found_any_nested_job = True
-                print(f"Note: Found nested job '{job['name']}' while job counts were equal.")
                 break
-        if not found_any_nested_job:
-            print("Note: Recursive and non-recursive calls found the same number of actual jobs, "
-                  "and no nested jobs were identified in the list. This is expected if all jobs are top-level.")
+        assert found_any_nested_job, \
+            (f"Recursive and non-recursive calls found the same number of actual jobs ({count_actual_jobs_recursive}), "
+             f"but no jobs with '/' in their names (indicative of subfolders) were identified. "
+             f"Given that subfolder jobs are expected in this environment, this indicates they were not found by the recursive call "
+             f"or not named with the conventional '/' separator. "
+             f"Jobs found: {[j.get('name') for j in actual_jobs_recursive]}")
 
     print("Recursive job listing test completed.")


### PR DESCRIPTION
- fixes: https://github.com/andreimatveyeu/mcp_jenkins/issues/2

## Solution 

The core issue was resolved by changing the method used to fetch jobs from the Jenkins server:

1.  **Switched to `jenkins_server.get_all_jobs()`:**
    *   In `src/jenkins_mcp_server/main.py`, within the `list_jobs` function, the call to `jenkins_server.get_jobs()` was replaced with `jenkins_server.get_all_jobs()`.
    *   The `get_all_jobs()` method recursively fetches all jobs and folders from the Jenkins instance and returns them as a flat list. This provides the `_get_and_filter_jobs_recursively` function with all the necessary data (including fullnames like `FolderName/JobName`) to correctly identify and structure nested jobs.

2.  **Enhanced Debugging and Logging (Supporting Steps):**
    To diagnose and confirm the fix, several improvements to logging were made:
    *   **Detailed Debug Logs:** Added extensive `logger.debug()` statements within the `list_jobs` function and its helper `_get_and_filter_jobs_recursively` in `src/jenkins_mcp_server/main.py` to trace the flow of data and logic.
    *   **Log Level Propagation to Test Container:** Modified `src/jenkins_mcp_server/docker/run.server.tests` to pass `LOG_LEVEL` and `DEBUG_MODE` environment variables from the host into the Docker container running the tests. This allows the server's log verbosity to be controlled during test runs (e.g., by `export LOG_LEVEL=DEBUG` on the host).
    *   **Test Log File Output:**
        *   Updated `src/jenkins_mcp_server/main.py` to conditionally add a `FileHandler` to the logger. This writes server logs to `src/jenkins_mcp_server/server_test.log` if the `WRITE_LOG_TO_FILE_FOR_TESTS` environment variable is set to `true`. The log file is overwritten for each test run.
        *   Modified `src/jenkins_mcp_server/docker/run.server.tests` to set `WRITE_LOG_TO_FILE_FOR_TESTS=true` in the test container, ensuring logs are written to this file, which is accessible on the host due to the volume mount.

With `jenkins_server.get_all_jobs()` providing the complete job list, the existing filtering logic now correctly identifies and returns nested jobs when `recursive=true`.
